### PR TITLE
Enable mods compatibility: Use Strings instead of ArmorMaterials.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/eu/codedsakura/setbonuses/config/ConfigSetBonus.java
+++ b/src/main/java/eu/codedsakura/setbonuses/config/ConfigSetBonus.java
@@ -7,13 +7,13 @@ import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.ArmorMaterials;
 
 public class ConfigSetBonus {
-    @Expose public boolean enabled = true;
-    @Expose public Effect[] effects = new Effect[0];
-    @Expose public float toughness = 0;
-    @Expose public float protection = 0;
-    @Expose public float knockbackResistance = 0;
-    @Expose public Partial partial = Partial.OFF;
-    @Expose public String material;
+    public boolean enabled = true;
+    public Effect[] effects = new Effect[0];
+    public float toughness = 0;
+    public float protection = 0;
+    public float knockbackResistance = 0;
+    public Partial partial = Partial.OFF;
+    public String material;
 
     public enum Partial {
         OFF, REDUCED_3, MISSING_CHEST

--- a/src/main/java/eu/codedsakura/setbonuses/config/ConfigSetBonus.java
+++ b/src/main/java/eu/codedsakura/setbonuses/config/ConfigSetBonus.java
@@ -1,17 +1,19 @@
 package eu.codedsakura.setbonuses.config;
 
+import com.google.gson.annotations.Expose;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ArmorItem;
+import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.ArmorMaterials;
 
 public class ConfigSetBonus {
-    public boolean enabled = true;
-    public Effect[] effects = new Effect[0];
-    public float toughness = 0;
-    public float protection = 0;
-    public float knockbackResistance = 0;
-    public Partial partial = Partial.OFF;
-    public ArmorMaterials material;
+    @Expose public boolean enabled = true;
+    @Expose public Effect[] effects = new Effect[0];
+    @Expose public float toughness = 0;
+    @Expose public float protection = 0;
+    @Expose public float knockbackResistance = 0;
+    @Expose public Partial partial = Partial.OFF;
+    @Expose public String material;
 
     public enum Partial {
         OFF, REDUCED_3, MISSING_CHEST
@@ -39,7 +41,7 @@ public class ConfigSetBonus {
                 if (pieces < 3) return -1;
                 if (pieces == 4) return effect.strength;
                 if (player.getInventory().armor.get(1).getItem() instanceof ArmorItem) {
-                    if (((ArmorItem) player.getInventory().armor.get(1).getItem()).getMaterial() == material) {
+                    if (((ArmorItem) player.getInventory().armor.get(1).getItem()).getMaterial().getName().toUpperCase().equals(material)) {
                         return -1;
                     }
                 }

--- a/src/main/java/eu/codedsakura/setbonuses/mixin/PlayerEntityMixin.java
+++ b/src/main/java/eu/codedsakura/setbonuses/mixin/PlayerEntityMixin.java
@@ -130,10 +130,10 @@ public class PlayerEntityMixin implements IPlayerEntityDuck {
 
     private void updateSetBonuses() {
         PlayerEntity self = (PlayerEntity) (Object) this;
-        Map<ArmorMaterial, Long> armorMap = self.getInventory().armor.stream()
+        Map<String, Long> armorMap = self.getInventory().armor.stream()
                 .map(ItemStack::getItem)
                 .filter(item -> item instanceof ArmorItem)
-                .map(item -> ((ArmorItem) item).getMaterial())
+                .map(item -> ((ArmorItem) item).getMaterial().getName().toUpperCase())
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
         HashSet<String> currentEffects = new HashSet<>();


### PR DESCRIPTION
This enables the mod to be used with other mods; tested with Mythic Metals.