### PR TITLE
Added waitDuration config for Effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Root:
 `effect`: [] = `[]` - array of potion effects  
 &gt; `id`: string [**Required!**]  
 &gt; `duration`: int = `210`
+&gt; `waitDuration`: boolean = `false` - wether the potion effect needs to run out before being reapplied or not, useful for effects like absorption and health boost
 &gt; `ambient`: boolean = `false`
 &gt; `showParticles`: boolean = `false`
 &gt; `showIcon`: boolean = `true`
@@ -57,6 +58,7 @@ Root:
 `effect`: [] = `[]` - array of potion effects  
 &gt; `id`: string [**Required!**]  
 &gt; `duration`: int = `210`  
+&gt; `waitDuration`: boolean = `false` - wether the potion effect needs to run out before being reapplied or not, useful for effects like absorption and health boost
 &gt; `ambient`: boolean = `false`  
 &gt; `showParticles`: boolean = `false`  
 &gt; `showIcon`: boolean = `true`  

--- a/src/main/java/eu/codedsakura/setbonuses/VirtualEnchantment.java
+++ b/src/main/java/eu/codedsakura/setbonuses/VirtualEnchantment.java
@@ -6,8 +6,6 @@ import eu.pb4.polymer.interfaces.VirtualObject;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ArmorItem;
-import net.minecraft.item.ArmorMaterial;
-import net.minecraft.item.ArmorMaterials;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;

--- a/src/main/java/eu/codedsakura/setbonuses/config/ConfigEnchant.java
+++ b/src/main/java/eu/codedsakura/setbonuses/config/ConfigEnchant.java
@@ -34,6 +34,7 @@ public class ConfigEnchant {
     public static class Effect {
         public String id;
         public int duration = 210;
+        public boolean waitDuration = false;
         public boolean ambient = false;
         public boolean showParticles = false;
         public boolean showIcon = true;

--- a/src/main/java/eu/codedsakura/setbonuses/mixin/PlayerEntityMixin.java
+++ b/src/main/java/eu/codedsakura/setbonuses/mixin/PlayerEntityMixin.java
@@ -7,6 +7,7 @@ import eu.codedsakura.setbonuses.config.ConfigSetBonus;
 import eu.codedsakura.setbonuses.ducks.IPlayerEntityDuck;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ArmorItem;
@@ -111,9 +112,12 @@ public class PlayerEntityMixin implements IPlayerEntityDuck {
 
                 for (ConfigEnchant.Effect effect : enchant.enchant.effects) {
                     currentEffects.add(effect.id);
-                    self.addStatusEffect(new StatusEffectInstance(
-                            Registry.STATUS_EFFECT.get(Identifier.tryParse(effect.id)), effect.duration + (CONFIG.updateInterval / 2),
-                            effectStrength - 1, effect.ambient, effect.showParticles, effect.showIcon));
+                    StatusEffect status = Registry.STATUS_EFFECT.get(Identifier.tryParse(effect.id));
+                    if(!effect.waitDuration || !self.hasStatusEffect(status)) {
+                        self.addStatusEffect(new StatusEffectInstance(
+                                status, effect.duration + (CONFIG.updateInterval / 2),
+                                effectStrength - 1, effect.ambient, effect.showParticles, effect.showIcon));
+                    }
                 }
             }
         }
@@ -148,10 +152,13 @@ public class PlayerEntityMixin implements IPlayerEntityDuck {
                 int strength = setBonus.getStrength(effect, self, armorMap.get(setBonus.material));
                 if (strength < 0) continue;
                 currentEffects.add(effect.id);
-                self.addStatusEffect(new StatusEffectInstance(
-                        Registry.STATUS_EFFECT.get(Identifier.tryParse(effect.id)), effect.duration,
-                        strength, effect.ambient,
-                        effect.showParticles, effect.showIcon));
+                StatusEffect status = Registry.STATUS_EFFECT.get(Identifier.tryParse(effect.id));
+                if(!effect.waitDuration || !self.hasStatusEffect(status)) {
+                    self.addStatusEffect(new StatusEffectInstance(
+                            status, effect.duration,
+                            strength, effect.ambient,
+                            effect.showParticles, effect.showIcon));
+                }
             }
 
             armorBuffs[0] += setBonus.protection * pieceCount;


### PR DESCRIPTION
This allows effects like Absorption and Health Boost to work by waiting for the effect to disappear before reapplying it.
Disabled by default to keep the original behavior.